### PR TITLE
Implement streams for WASM target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,6 @@ dependencies = [
  "indoc",
  "log",
  "log4rs",
- "nom",
  "notify",
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,9 @@ dependencies = [
  "tree-sitter-c2rust",
  "tree-sitter-sparql",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasm-logger",
+ "web-sys",
 ]
 
 [[package]]
@@ -656,10 +658,11 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1398,9 +1401,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1409,13 +1412,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -1423,10 +1425,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.95"
+name = "wasm-bindgen-futures"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1434,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1447,9 +1462,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "wasm-logger"
@@ -1464,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,12 @@ streaming-iterator = "0.1.9"
 
 # wasm
 wasm-bindgen = "0.2.95"
-web-sys = { version = "0.3.76", features = ["ReadableStream", "ReadableStreamDefaultReader", "WritableStream", "WritableStreamDefaultWriter"] }
+web-sys = { version = "0.3.76", features = [
+	"ReadableStream",
+	"ReadableStreamDefaultReader",
+	"WritableStream",
+	"WritableStreamDefaultWriter",
+] }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 getrandom = { version = "0.2", features = ["js"] }
 serde-wasm-bindgen = "0.6.5"
@@ -52,7 +57,6 @@ camino = "1.1.9"
 
 # misc
 indoc = "2.0.5"
-nom = "7.1.3"
 config = "0.14.0"
 notify = "6.1.1"
 wasm-bindgen-futures = "0.4.49"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.14"
 edition = "2021"
 authors = ["Ioannis Nezis <ioannis@nezis.de>"]
 description = "A formatter for SPARQL queries"
-repository = "https://github.com/IoannisNezis/sparql-language-server"
+repository = "git+https://github.com/IoannisNezis/sparql-language-server.git"
 license = "MIT"
 license-file = "LICENSE"
 keywords = ["SPARQL", "formatter", "lsp", "wasm"]
@@ -37,9 +37,11 @@ tree-sitter = { package = "tree-sitter-c2rust", version = "0.24.3" }
 # tree-sitter = "0.24.3"
 tree-sitter-sparql = { version = "0.24" }
 # tree-sitter-sparql = { path = "../tree-sitter-sparql/" }
+streaming-iterator = "0.1.9"
 
 # wasm
 wasm-bindgen = "0.2.95"
+web-sys = { version = "0.3.76", features = ["ReadableStream", "ReadableStreamDefaultReader", "WritableStream", "WritableStreamDefaultWriter"] }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 getrandom = { version = "0.2", features = ["js"] }
 serde-wasm-bindgen = "0.6.5"
@@ -53,7 +55,7 @@ indoc = "2.0.5"
 nom = "7.1.3"
 config = "0.14.0"
 notify = "6.1.1"
-streaming-iterator = "0.1.9"
+wasm-bindgen-futures = "0.4.49"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasm-logger = { version = "0.2.0" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,51 @@
 mod server;
 
+use log::error;
 use server::Server;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::JsFuture;
+use web_sys::js_sys;
+
+async fn read_message(
+    reader: &web_sys::ReadableStreamDefaultReader,
+) -> Result<(String, bool), String> {
+    match JsFuture::from(reader.read()).await {
+        Ok(js_object) => {
+            let value = js_sys::Reflect::get(&js_object, &"value".into())
+                .map_err(|_| "\"value\" property not present in message")?
+                .as_string()
+                .ok_or("\"value\" is not a string")?;
+            let done = js_sys::Reflect::get(&js_object, &"done".into())
+                .map_err(|_| "\"done\" property not present in message")?
+                .as_bool()
+                .ok_or("\"done\" is not a boolean")?;
+            Ok((value, done))
+        }
+        Err(_) => Err("Error while reading from input-stream".to_string()),
+    }
+}
+
+fn send_message(writer: &web_sys::WritableStreamDefaultWriter, message: String) {
+    let _future = JsFuture::from(writer.write_with_chunk(&message.into()));
+}
 
 #[wasm_bindgen]
-pub fn init_language_server() -> Server {
+pub async fn start_language_server(
+    reader: web_sys::ReadableStreamDefaultReader,
+    writer: web_sys::WritableStreamDefaultWriter,
+) {
     #[cfg(target_arch = "wasm32")]
     wasm_logger::init(wasm_logger::Config::default());
-    return Server::new();
+    let mut server = Server::new(move |message| send_message(&writer, message));
+    loop {
+        match read_message(&reader).await {
+            Ok((value, done)) => {
+                server.handle_message(value);
+                if done {
+                    break;
+                }
+            }
+            Err(e) => error!("{}", e),
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ mod server;
 
 use std::{
     fs::{File, OpenOptions},
-    io::{BufRead, BufReader, Read, Seek, Write},
+    io::{self, BufRead, BufReader, Read, Seek, Write},
     path::PathBuf,
     sync::mpsc::channel,
 };
@@ -62,6 +62,11 @@ fn configure_logging() {
     log4rs::init_config(config).expect("Failed to configure logger");
 }
 
+fn send_message(message: String) {
+    print!("Content-Length: {}\r\n\r\n{}", message.len(), message);
+    io::stdout().flush().expect("No IO errors or EOFs");
+}
+
 fn main() {
     #[cfg(not(target_arch = "wasm32"))]
     configure_logging();
@@ -70,7 +75,7 @@ fn main() {
     match cli.command {
         Command::Server => {
             // Start server and listen to stdio
-            let mut server = Server::new();
+            let mut server = Server::new(send_message);
             server.listen_stdio();
         }
         Command::Format { path } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod server;
+mod stdio_reader;
 
 use std::{
     fs::{File, OpenOptions},
@@ -19,6 +20,7 @@ use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use server::{format_raw, Server};
 
 use clap::{Parser, Subcommand};
+use stdio_reader::listen_stdio;
 
 /// fichu: An SPARQL language server and formatter
 #[derive(Debug, Parser)]
@@ -76,7 +78,7 @@ fn main() {
         Command::Server => {
             // Start server and listen to stdio
             let mut server = Server::new(send_message);
-            server.listen_stdio();
+            listen_stdio(|message| server.handle_message(message));
         }
         Command::Format { path } => {
             match File::open(path.clone()) {

--- a/src/server/lsp/messages/window_showmessage.rs
+++ b/src/server/lsp/messages/window_showmessage.rs
@@ -12,10 +12,13 @@ pub struct ShowMessageNotification {
 
 #[allow(dead_code)]
 impl ShowMessageNotification {
-    pub fn new(message: String, kind: MessageType) -> Self {
+    pub fn new(message: &str, kind: MessageType) -> Self {
         Self {
             base: BaseMessage::new("window/showMessage"),
-            params: ShowMessageParams { kind, message },
+            params: ShowMessageParams {
+                kind,
+                message: message.to_string(),
+            },
         }
     }
 }

--- a/src/server/lsp/rpc.rs
+++ b/src/server/lsp/rpc.rs
@@ -1,13 +1,4 @@
-use nom::{
-    bytes::complete::{tag, take_while},
-    IResult,
-};
 use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct Header {
-    pub content_length: usize,
-}
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct BaseMessage {
@@ -56,20 +47,6 @@ struct ResponseError {
     data: Option<String>,
 }
 
-impl Header {
-    pub fn from_string(string: String) -> Result<Header, String> {
-        let (_rest, content_length) =
-            Header::parse(string.as_str()).expect("Expected valid header");
-        Ok(Header { content_length })
-    }
-
-    fn parse(input: &str) -> IResult<&str, usize> {
-        let (input, _) = tag("Content-Length: ")(input)?;
-        let (input, number) = take_while(|c: char| c.is_digit(10))(input)?;
-        Ok((input, number.parse().unwrap()))
-    }
-}
-
 pub fn decode_message(message: &String) -> Result<BaseMessage, String> {
     let request: BaseMessage = serde_json::from_str(&message).expect("A valid Message");
     return Ok(request);
@@ -78,20 +55,9 @@ pub fn decode_message(message: &String) -> Result<BaseMessage, String> {
 #[cfg(test)]
 mod tests {
 
-    use crate::server::lsp::rpc::{BaseMessage, Header};
+    use crate::server::lsp::rpc::BaseMessage;
 
     use super::decode_message;
-
-    #[test]
-    fn header_parses() {
-        let header_string: String = "Content-Length: 12345\r\n\r\n".to_owned();
-        assert_eq!(
-            Header::from_string(header_string),
-            Ok(Header {
-                content_length: 12345
-            })
-        );
-    }
 
     #[test]
     fn test_decode() {

--- a/src/server/lsp/rpc.rs
+++ b/src/server/lsp/rpc.rs
@@ -70,9 +70,8 @@ impl Header {
     }
 }
 
-pub fn decode_message(msg: &Vec<u8>) -> Result<BaseMessage, String> {
-    let msg_string = String::from_utf8(msg.to_vec()).unwrap();
-    let request: BaseMessage = serde_json::from_str(&msg_string).expect("A valid Message");
+pub fn decode_message(message: &String) -> Result<BaseMessage, String> {
+    let request: BaseMessage = serde_json::from_str(&message).expect("A valid Message");
     return Ok(request);
 }
 
@@ -97,8 +96,7 @@ mod tests {
     #[test]
     fn test_decode() {
         let maybe_request = decode_message(
-            &b"{\"jsonrpc\": \"2.0\",\"id\": 1, \"method\": \"initialize\", \"params\": {}}"
-                .to_vec(),
+            &r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#.to_string(),
         );
         assert_eq!(
             maybe_request,

--- a/src/server/message_handler/mod.rs
+++ b/src/server/message_handler/mod.rs
@@ -21,7 +21,7 @@ use super::{
         textdocument::TextDocumentItem,
         CompletionRequest, Diagnostic, DiagnosticRequest, DiagnosticResponse,
         DidChangeTextDocumentNotification, DidOpenTextDocumentNotification, FormattingRequest,
-        HoverRequest, InitializeRequest, MessageType, ShowMessageNotification, ShutdownResponse,
+        HoverRequest, InitializeRequest, ShutdownResponse,
     },
     state::ServerStatus,
     Server,

--- a/src/server/message_handler/mod.rs
+++ b/src/server/message_handler/mod.rs
@@ -21,16 +21,16 @@ use super::{
         textdocument::TextDocumentItem,
         CompletionRequest, Diagnostic, DiagnosticRequest, DiagnosticResponse,
         DidChangeTextDocumentNotification, DidOpenTextDocumentNotification, FormattingRequest,
-        HoverRequest, InitializeRequest, ShutdownResponse,
+        HoverRequest, InitializeRequest, MessageType, ShowMessageNotification, ShutdownResponse,
     },
     state::ServerStatus,
     Server,
 };
 
-pub fn dispatch(server: &mut Server, bytes: &Vec<u8>) -> Option<String> {
-    if let Ok(message) = rpc::decode_message(bytes) {
+pub fn dispatch(server: &mut Server, message_string: String) -> Option<String> {
+    if let Ok(message) = rpc::decode_message(&message_string) {
         match message.method.as_str() {
-            "initialize" => match serde_json::from_slice::<InitializeRequest>(bytes) {
+            "initialize" => match serde_json::from_str::<InitializeRequest>(&message_string) {
                 Ok(initialize_request) => {
                     let response = handle_initialize_request(&server, initialize_request);
                     return Some(serde_json::to_string(&response).unwrap());
@@ -45,7 +45,7 @@ pub fn dispatch(server: &mut Server, bytes: &Vec<u8>) -> Option<String> {
                 server.state.status = ServerStatus::Running;
                 return None;
             }
-            "shutdown" => match serde_json::from_slice::<RequestMessage>(bytes) {
+            "shutdown" => match serde_json::from_str::<RequestMessage>(&message_string) {
                 Ok(shutdown_request) => {
                     info!("recieved shutdown request, preparing to shut down");
                     let response = ShutdownResponse::new(shutdown_request.id);
@@ -62,7 +62,7 @@ pub fn dispatch(server: &mut Server, bytes: &Vec<u8>) -> Option<String> {
                 exit(0);
             }
             "textDocument/didOpen" => {
-                match serde_json::from_slice::<DidOpenTextDocumentNotification>(bytes) {
+                match serde_json::from_str::<DidOpenTextDocumentNotification>(&message_string) {
                     Ok(did_open_notification) => {
                         debug!(
                             "opened text document: \"{}\"\n{}",
@@ -81,7 +81,7 @@ pub fn dispatch(server: &mut Server, bytes: &Vec<u8>) -> Option<String> {
                 }
             }
             "textDocument/didChange" => {
-                match serde_json::from_slice::<DidChangeTextDocumentNotification>(bytes) {
+                match serde_json::from_str::<DidChangeTextDocumentNotification>(&message_string) {
                     Ok(did_change_notification) => {
                         debug!(
                             "text document changed: {}",
@@ -103,7 +103,7 @@ pub fn dispatch(server: &mut Server, bytes: &Vec<u8>) -> Option<String> {
                     }
                 }
             }
-            "textDocument/hover" => match serde_json::from_slice::<HoverRequest>(bytes) {
+            "textDocument/hover" => match serde_json::from_str::<HoverRequest>(&message_string) {
                 Ok(hover_request) => {
                     debug!(
                         "recieved hover request for {} {}",
@@ -119,64 +119,71 @@ pub fn dispatch(server: &mut Server, bytes: &Vec<u8>) -> Option<String> {
                     return None;
                 }
             },
-            "textDocument/completion" => match serde_json::from_slice::<CompletionRequest>(bytes) {
-                Ok(completion_request) => {
-                    debug!(
-                        "Received completion request for {} {}",
-                        completion_request.get_document_uri(),
-                        completion_request.get_position()
-                    );
-                    let response = handel_completion_request(completion_request, &mut server.state);
-                    return Some(serde_json::to_string(&response).unwrap());
+            "textDocument/completion" => {
+                match serde_json::from_str::<CompletionRequest>(&message_string) {
+                    Ok(completion_request) => {
+                        debug!(
+                            "Received completion request for {} {}",
+                            completion_request.get_document_uri(),
+                            completion_request.get_position()
+                        );
+                        let response =
+                            handel_completion_request(completion_request, &mut server.state);
+                        return Some(serde_json::to_string(&response).unwrap());
+                    }
+                    Err(error) => {
+                        error!(
+                            "Could not parse textDocument/completion request: {:?}",
+                            error
+                        );
+                        return None;
+                    }
                 }
-                Err(error) => {
-                    error!(
-                        "Could not parse textDocument/completion request: {:?}",
-                        error
-                    );
-                    return None;
+            }
+            "textDocument/formatting" => {
+                match serde_json::from_str::<FormattingRequest>(&message_string) {
+                    Ok(formatting_request) => {
+                        let response = handle_format_request(
+                            formatting_request,
+                            &mut server.state,
+                            &server.settings,
+                        );
+                        return Some(serde_json::to_string(&response).unwrap());
+                    }
+                    Err(error) => {
+                        error!(
+                            "Could not parse textDocument/formatting request: {:?}",
+                            error
+                        );
+                        return None;
+                    }
                 }
-            },
-            "textDocument/formatting" => match serde_json::from_slice::<FormattingRequest>(bytes) {
-                Ok(formatting_request) => {
-                    let response = handle_format_request(
-                        formatting_request,
-                        &mut server.state,
-                        &server.settings,
-                    );
-                    return Some(serde_json::to_string(&response).unwrap());
+            }
+            "textDocument/diagnostic" => {
+                match serde_json::from_str::<DiagnosticRequest>(&message_string) {
+                    Ok(diagnostic_request) => {
+                        let diagnostics: Vec<Diagnostic> = collect_diagnostics(
+                            &server.state,
+                            &diagnostic_request.params.text_document.uri,
+                        )
+                        .collect();
+                        let resonse =
+                            DiagnosticResponse::new(diagnostic_request.base.id, diagnostics);
+                        return Some(serde_json::to_string(&resonse).unwrap());
+                    }
+                    Err(error) => {
+                        error!(
+                            "Could not parse textDocument/diagnostic request: {:?}",
+                            error
+                        );
+                        return None;
+                    }
                 }
-                Err(error) => {
-                    error!(
-                        "Could not parse textDocument/formatting request: {:?}",
-                        error
-                    );
-                    return None;
-                }
-            },
-            "textDocument/diagnostic" => match serde_json::from_slice::<DiagnosticRequest>(bytes) {
-                Ok(diagnostic_request) => {
-                    let diagnostics: Vec<Diagnostic> = collect_diagnostics(
-                        &server.state,
-                        &diagnostic_request.params.text_document.uri,
-                    )
-                    .collect();
-                    let resonse = DiagnosticResponse::new(diagnostic_request.base.id, diagnostics);
-                    return Some(serde_json::to_string(&resonse).unwrap());
-                }
-                Err(error) => {
-                    error!(
-                        "Could not parse textDocument/diagnostic request: {:?}",
-                        error
-                    );
-                    return None;
-                }
-            },
+            }
             unknown_method => {
                 warn!(
                     "Received message with unknown method \"{}\": {:?}",
-                    unknown_method,
-                    String::from_utf8(bytes.to_vec()).unwrap()
+                    unknown_method, message_string
                 );
                 return None;
             }

--- a/src/stdio_reader.rs
+++ b/src/stdio_reader.rs
@@ -1,0 +1,65 @@
+use core::panic;
+use std::{
+    io::{self, BufReader, Read},
+    process::exit,
+};
+
+use log::error;
+
+pub fn listen_stdio(mut message_handler: impl FnMut(String) -> ()) {
+    let stdin = io::stdin();
+    let reader = BufReader::new(stdin);
+
+    let mut bytes = reader.bytes();
+    let mut buffer = vec![];
+
+    loop {
+        match bytes.next() {
+            Some(Ok(byte)) => {
+                buffer.push(byte);
+            }
+            Some(Err(error)) => {
+                error!("Error while reading byte: {}", error);
+                panic!("{}", error);
+            }
+            None => {
+                error!("Stream ended unexpected while waiting for header, shutting down");
+                exit(1);
+            }
+        }
+        if buffer.ends_with(b"\r\n\r\n") {
+            let cl_slice = buffer
+                .get(16..(buffer.len() - 4))
+                .expect("Header does not have a 'Content-Length: '");
+            let cl_string =
+                String::from_utf8(cl_slice.to_vec().clone()).expect("Invalid UTF-8 data");
+            let content_length: u32 = cl_string.parse().expect("Failed to parse Content-Length");
+            buffer.clear();
+            for ele in 0..content_length {
+                match bytes.next() {
+                    Some(Ok(byte)) => {
+                        buffer.push(byte);
+                    }
+                    Some(Err(err)) => {
+                        error!(
+                            "Error {} occured while reading byte {} of {}, clearing buffer",
+                            err, ele, content_length
+                        );
+                        buffer.clear();
+                        break;
+                    }
+                    None => {
+                        error!(
+                            "Byte stream endet after {} of {} bytes, clearing message buffer",
+                            ele, content_length
+                        );
+                        buffer.clear();
+                        break;
+                    }
+                }
+            }
+            (message_handler)(String::from_utf8(buffer.clone()).unwrap());
+            buffer.clear();
+        }
+    }
+}


### PR DESCRIPTION
At the moment the lib entry-point (and thereby the WASM target) does not have a way to read or write to a stream.
This PR implements this.
It also abstracts the way the language server sends messages s.t. it will send to stdout when run native
and to a [WritableStreamDefaultWriter](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter) wen run in the browser.

In the current setup the entrypoint (lib.rs or main.rs) is responsible for feeding the language server with the incoming messages.